### PR TITLE
fix: define `cconvert` to make `pointer` work as intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ Types of changes:
 - `Security` in case of vulnerabilities.
 -->
 
+## [Unreleased]
+
+### Added
+
+- Define also `Base.cconvert`. Fixes [#10].
+
+### Fixed
+
+- Error while calling `pointer` ([#10]).
+
+[#10]: https://github.com/FedericoStra/ProtectedArrays.jl/issues/10
+
 ## [0.2.0]
 
 ### Added
@@ -51,6 +63,7 @@ Types of changes:
 
 Empty project.
 
+[Unreleased]: https://github.com/FedericoStra/ProtectedArrays.jl/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/FedericoStra/ProtectedArrays.jl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/FedericoStra/ProtectedArrays.jl/compare/v0.0.0...v0.1.0
 [0.0.0]: https://github.com/FedericoStra/ProtectedArrays.jl/releases/tag/v0.0.0

--- a/src/strided_array.jl
+++ b/src/strided_array.jl
@@ -19,6 +19,9 @@
 
 @inline Base.elsize(::Type{ProtectedArray{T, N, A}}) where {T, N, A} = Base.elsize(A)
 
+@inline function Base.cconvert(::Type{Ptr{T}}, pa::ProtectedArray{T}) where {T}
+    return Base.cconvert(Ptr{T}, parent(pa))
+end
 @inline function Base.unsafe_convert(::Type{Ptr{T}}, pa::ProtectedArray{T}) where {T}
     return Base.unsafe_convert(Ptr{T}, parent(pa))
 end

--- a/test/test_strided_array.jl
+++ b/test/test_strided_array.jl
@@ -28,6 +28,22 @@ function test_strided_array(a::AbstractArray)
             @test pointer(a, 1) == pointer(a, 1)
         end
 
+        try
+            Base.unsafe_convert(Ptr{Int}, a)
+        catch
+            # Skip the tests.
+        else
+            @test Base.unsafe_convert(Ptr{Int}, a) == Base.unsafe_convert(Ptr{Int}, a)
+        end
+
+        try
+            Base.cconvert(Ptr{Int}, a)
+        catch
+            # Skip the tests.
+        else
+            @test Base.cconvert(Ptr{Int}, a) == Base.cconvert(Ptr{Int}, a)
+        end
+
         @test parent(pa) === a
         @test parent(pa) == backup
     end

--- a/test/test_strided_array.jl
+++ b/test/test_strided_array.jl
@@ -17,7 +17,7 @@ function test_strided_array(a::AbstractArray)
         catch
             # Skip the tests.
         else
-            @test pointer(a) == pointer(a)
+            @test pointer(pa) == pointer(a)
         end
 
         try
@@ -25,7 +25,7 @@ function test_strided_array(a::AbstractArray)
         catch
             # Skip the tests.
         else
-            @test pointer(a, 1) == pointer(a, 1)
+            @test pointer(pa, 1) == pointer(a, 1)
         end
 
         try
@@ -33,7 +33,7 @@ function test_strided_array(a::AbstractArray)
         catch
             # Skip the tests.
         else
-            @test Base.unsafe_convert(Ptr{Int}, a) == Base.unsafe_convert(Ptr{Int}, a)
+            @test Base.unsafe_convert(Ptr{Int}, pa) == Base.unsafe_convert(Ptr{Int}, a)
         end
 
         try
@@ -41,7 +41,7 @@ function test_strided_array(a::AbstractArray)
         catch
             # Skip the tests.
         else
-            @test Base.cconvert(Ptr{Int}, a) == Base.cconvert(Ptr{Int}, a)
+            @test Base.cconvert(Ptr{Int}, pa) == Base.cconvert(Ptr{Int}, a)
         end
 
         @test parent(pa) === a

--- a/test/test_strided_array.jl
+++ b/test/test_strided_array.jl
@@ -12,6 +12,22 @@ function test_strided_array(a::AbstractArray)
             @test stride(pa, d) == stride(a, d)
         end
 
+        try
+            pointer(a)
+        catch
+            # Skip the tests.
+        else
+            @test pointer(a) == pointer(a)
+        end
+
+        try
+            pointer(a, 1)
+        catch
+            # Skip the tests.
+        else
+            @test pointer(a, 1) == pointer(a, 1)
+        end
+
         @test parent(pa) === a
         @test parent(pa) == backup
     end


### PR DESCRIPTION
Fixes #10.